### PR TITLE
Fix ladder overlap by spacing them out

### DIFF
--- a/src/components/PlatformerCanvas.tsx
+++ b/src/components/PlatformerCanvas.tsx
@@ -50,11 +50,13 @@ const PlatformerCanvas: React.FC = () => {
         groundYs.push(h * groundPositions[i]);
       }
 
-      ladderXs[0] = app.screen.width - ladderWidth * 2;
-      ladderXs[1] = app.screen.width / 2;
-      ladderXs[2] = app.screen.width - ladderWidth * 2;
-      ladderXs[3] = app.screen.width - ladderWidth * 2;
-      ladderXs[4] = app.screen.width - ladderWidth * 2;
+      // Stagger ladder positions so each one is offset from the previous
+      // while still alternating sides based on ladderDirs.
+      ladderXs[0] = app.screen.width * 0.85 - ladderWidth;
+      ladderXs[1] = app.screen.width * 0.15;
+      ladderXs[2] = app.screen.width * 0.75 - ladderWidth;
+      ladderXs[3] = app.screen.width * 0.25;
+      ladderXs[4] = app.screen.width * 0.65 - ladderWidth;
     };
 
     computeLayout();

--- a/todo.md
+++ b/todo.md
@@ -13,6 +13,7 @@
 - [x] Add additional staircases to extend the level
 - [x] Shorten inaccessible platforms behind ladders
 - [x] Ensure ladder sequence forms a complete path to the flag
+- [x] Adjust ladder x positions to prevent overlap
 - [ ] Expand info panels with more details
 - [ ] Add sprite graphics and animations for the character
 - [x] Set up build and type-check scripts (npm run build, npm run typecheck)


### PR DESCRIPTION
## Summary
- keep `todo.md` up to date
- spread ladders across the level so no two ladders share an x coordinate

## Testing
- `npm run build`
- `npm run typecheck`
